### PR TITLE
WINDOW_NOT_FOUND catch

### DIFF
--- a/src/errors/helper.js
+++ b/src/errors/helper.js
@@ -178,6 +178,10 @@ module.exports = {
         else if (err.message === 'java.net.ConnectException: Connection refused: connect') {
             return new OxError(ERROR_CODES.WEBDRIVER_ERROR, 'The underlying WebDriver seems to have crashed: ' + err.message);
         }
+        //  when doing an operation on an element (e.g. click) but the window was already closed
+        else if (err.message && err.message.includes('no such window') && err.message.includes('target window already closed') && err.message.includes('web view not found')) {
+            return new OxError(ERROR_CODES.WINDOW_NOT_FOUND, err.message);
+        }
 
         // try to resolve Chai error code
         var oxErrorCode = CHAI_ERROR_CODES[errType];


### PR DESCRIPTION
Sample script:

web.init();
web.setTimeout(6000);
web.open('https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_link_target');
const title = web.getTitle();
web.selectFrame('id=iframeResult');
const el = web.findElement('/html/body/a');
web.click(el);
web.pause(10000);
const hs = web.getWindowHandles();
log.info(hs);

web.selectWindow(hs[0]);
web.closeWindow();

web.click(el);
