### PR TITLE
OI-950 Handle stale element reference errors

### DIFF
--- a/src/errors/helper.js
+++ b/src/errors/helper.js
@@ -178,6 +178,10 @@ module.exports = {
         else if (err.message === 'java.net.ConnectException: Connection refused: connect') {
             return new OxError(ERROR_CODES.WEBDRIVER_ERROR, 'The underlying WebDriver seems to have crashed: ' + err.message);
         }
+        // stale element reference
+        else if (err.name && err.name.includes('stale element reference')) {
+            return new OxError(ERROR_CODES.STALE_ELEMENT_REFERENCE, err.name + ' ' + err.message);
+        }
 
         // try to resolve Chai error code
         var oxErrorCode = CHAI_ERROR_CODES[errType];


### PR DESCRIPTION
Reproduce var clickable = false; in web.click
Script:
web.init({
    browserName: 'ie'
});
web.setTimeout(6000);
web.open('https://www.w3schools.com/');
const selector = '/html/body/div[4]/div/a[1]/i';
const element = web.findElement(selector);
web.execute(function() {
    location.reload();
});
web.click(element);
web.pause(10000);
web.click(element);