### PR TITLE
Detect browserstack provider with proper keyword

### DIFF
--- a/src/ox_modules/module-mob.js
+++ b/src/ox_modules/module-mob.js
@@ -231,9 +231,9 @@ export default class MobileModule extends WebDriverModule {
             delete wdioOpts.capabilities['perfectoMobile:options'];
         }
 
-        if (wdioOpts.capabilities['browserstack:options'] && wdioOpts.capabilities['browserstack:options']['name']) {
-            name = wdioOpts.capabilities['browserstack:options']['name'];
-            delete wdioOpts.capabilities['browserstack:options'];
+        if (wdioOpts.capabilities['bstack:options'] && wdioOpts.capabilities['bstack:options']['name']) {
+            name = wdioOpts.capabilities['bstack:options']['name'];
+            delete wdioOpts.capabilities['bstack:options'];
         }
 
         this.wdioOpts = wdioOpts;

--- a/src/ox_modules/module-web.js
+++ b/src/ox_modules/module-web.js
@@ -228,9 +228,9 @@ export default class WebModule extends WebDriverModule {
             name = wdioOpts.capabilities['testingBot:options']['name'];
             delete wdioOpts.capabilities['testingBot:options'];
         }
-        if (wdioOpts.capabilities['browserstack:options'] && wdioOpts.capabilities['browserstack:options']['name']) {
-            name = wdioOpts.capabilities['browserstack:options']['name'];
-            delete wdioOpts.capabilities['browserstack:options'];
+        if (wdioOpts.capabilities['bstack:options'] && wdioOpts.capabilities['bstack:options']['name']) {
+            name = wdioOpts.capabilities['bstack:options']['name'];
+            delete wdioOpts.capabilities['bstack:options'];
         }
         this.wdioOpts = wdioOpts;
 

--- a/src/ox_modules/utils.js
+++ b/src/ox_modules/utils.js
@@ -392,7 +392,7 @@ module.exports = {
 
         if (wdioOpts.capabilities['perfectoMobile:options'] || (wdioOpts.hostname && wdioOpts.hostname.includes('perfectomobile.com'))) {
             return providers.PERFECTO;
-        } else if (wdioOpts.capabilities['browserstack:options']) {
+        } else if (wdioOpts.capabilities['bstack:options']) {
             return providers.BROWSERSTACK;
         } else if (wdioOpts.capabilities['sauce:options']) {
             return providers.SAUCELABS;


### PR DESCRIPTION
based on this doc: https://webdriver.io/docs/options/#capabilities
browserstack options will be passed using the `bstack:options` keyword